### PR TITLE
fix directory exists error

### DIFF
--- a/ehDown.js
+++ b/ehDown.js
@@ -103,7 +103,7 @@ class EhDownload extends EhImg {
             let stat = fs.statSync(path);
             stat = fs.statSync(this._path);
         } catch (e) {
-            fs.mkdirSync(path);
+            if (!fs.existsSync(path)) fs.mkdirSync(path);
             fs.mkdirSync(this._path);
             this._mkdir(path);
         }


### PR DESCRIPTION
修复下载画廊时，文件夹已存在时导致的错误